### PR TITLE
Run GitHub Actions CI on macos-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           npm run all
   test: # make sure the action works on a clean machine without building
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - name: Setup SDL2 frameworks


### PR DESCRIPTION
macOS-12 runners are deprecated and causes CI error.